### PR TITLE
Fix: fix ubuntu compile error

### DIFF
--- a/pentacore/include/util/Environment.hpp
+++ b/pentacore/include/util/Environment.hpp
@@ -19,9 +19,9 @@
 #define _ENVIRONMENT_HPP_
 #include <string>
 #include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
 #ifdef __APPLE__
-     #include <sys/types.h>
-     #include <pwd.h>
      #include <uuid/uuid.h>
 #endif
 


### PR DESCRIPTION
Fixed ubuntu compilation error, due to precompile guard excluding the required system includes.